### PR TITLE
g2g element backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Run black check
         run: black --check plugins/ tests/ utils/
 
+      # Scoped to this file on purpose: test_pipelines.py raises on import when
+      # gst-launch-1.0 is missing, which would fail collection for the whole dir.
+      - name: Run g2g backend tests
+        run: |
+          pip install pytest numpy
+          pytest tests/test_g2g_backend.py -q
+
   build:
     needs: lint
     strategy:

--- a/plugins/python/backend/__init__.py
+++ b/plugins/python/backend/__init__.py
@@ -38,8 +38,20 @@ if BACKEND == "gst":
         FlowReturn,
         GObject,
     )
+elif BACKEND == "g2g":
+    from backend.g2g import (
+        BaseTransform,
+        BaseAggregator,
+        VideoTransform,
+        analytics,
+        frameio,
+        FlowReturn,
+        GObject,
+    )
 else:
-    raise ImportError(f"Unknown GSTML_BACKEND={BACKEND!r}; supported backends: 'gst'")
+    raise ImportError(
+        f"Unknown GSTML_BACKEND={BACKEND!r}; supported backends: 'gst', 'g2g'"
+    )
 
 __all__ = [
     "BACKEND",

--- a/plugins/python/backend/g2g/__init__.py
+++ b/plugins/python/backend/g2g/__init__.py
@@ -1,0 +1,36 @@
+# g2g backend
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""g2g backend: element bases plus the frame I/O and analytics implementations.
+
+The counterpart of `backend.gst`, targeting the glass2glass (`g2g`) host instead
+of GStreamer. Elements are plain Python objects the host drives via
+`g2g_process` / `g2g_process_batch`; there is no GObject type system or GstBase
+element, so `GObject` / `FlowReturn` are lightweight shims (see `shims.py`) that
+let leaf element code load unchanged. Selected by `GSTML_BACKEND=g2g`.
+
+Unlike the gst backend, no `gi` is imported anywhere here, so a leaf element can
+be hosted with no GStreamer present at all.
+"""
+
+from backend.g2g.shims import GObject, FlowReturn  # noqa: F401
+from backend.g2g.analytics import analytics  # noqa: F401
+from backend.g2g.frameio import frameio  # noqa: F401
+from backend.g2g.transform import BaseTransform  # noqa: F401
+from backend.g2g.video_transform import VideoTransform  # noqa: F401
+from backend.g2g.aggregator import BaseAggregator  # noqa: F401
+
+__all__ = [
+    "BaseTransform",
+    "BaseAggregator",
+    "VideoTransform",
+    "analytics",
+    "frameio",
+    "FlowReturn",
+    "GObject",
+]

--- a/plugins/python/backend/g2g/aggregator.py
+++ b/plugins/python/backend/g2g/aggregator.py
@@ -1,0 +1,51 @@
+# BaseAggregator (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""g2g backend for the `aggregator` element family (N inputs -> 1 output).
+
+The host calls `g2g_process_batch([buf, ...], w, h, fmt, sink)` with one
+`FrameBuffer` per input. This base reads each into a frame and hands the stacked
+batch to `process_batch`, the framework-agnostic hook the leaf supplies.
+"""
+
+import numpy as np
+
+from backend.g2g.analytics import analytics
+from backend.g2g.frameio import frameio
+from backend.g2g.transform import BaseTransform
+
+
+class BaseAggregator(BaseTransform):
+    """Base for g2g ML aggregator elements (input format may differ from output)."""
+
+    def __init__(self):
+        super().__init__()
+        self.width = 0
+        self.height = 0
+
+    def process_batch(self, frames, num_sources, fmt, target):
+        """Run inference over the batched inputs. The concrete element supplies
+        this (the same hook the gst aggregator drives)."""
+        raise NotImplementedError("leaf element must implement process_batch")
+
+    def g2g_process_batch(self, buffers, width, height, fmt, sink):
+        self.width = width
+        self.height = height
+        frameio.bind(sink, fmt)
+        analytics.bind(sink)
+        self._ensure_model()
+        frames = []
+        for buf in buffers:
+            frame = frameio.read_frame(buf, None, width, height)
+            if frame is not None:
+                frames.append(frame)
+        if not frames:
+            return None
+        batch = np.stack(frames, axis=0)
+        self.process_batch(batch, len(frames), fmt, buffers[0] if buffers else None)
+        return None

--- a/plugins/python/backend/g2g/analytics.py
+++ b/plugins/python/backend/g2g/analytics.py
@@ -1,0 +1,119 @@
+# G2gAnalyticsBackend (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""Analytics metadata over the g2g host's `MetaSink`.
+
+GStreamer attaches a `GstAnalyticsRelationMeta` to the buffer and relates
+detections, classifications and tracking records. The g2g host instead hands the
+element a flat, write-only `MetaSink` per frame with `add_object(label, x, y, w,
+h, score)` / `add_classification(label, score)` / `add_blob(...)`; the host then
+materializes those into the frame's `AnalyticsMeta`. This backend maps the rich
+`AnalyticsBackend` interface the leaf task code uses onto that flat sink:
+
+  * the "relation meta" handle is a thin wrapper over the bound sink that counts
+    how many records were staged (so `relation_length` works);
+  * string labels are interned to the `u32` ids the sink expects (`quark`);
+  * tracking relations and read-back are not represented by the flat sink, so
+    `add_tracking` / `relate` / `read_objects` are no-ops for now.
+"""
+
+from backend.analytics import AnalyticsBackend
+
+
+class _RelationMeta:
+    """The g2g stand-in for a buffer's relation meta: the bound sink plus a count
+    of staged records (GstAnalytics tracks relations; the flat sink only counts)."""
+
+    def __init__(self, sink):
+        self.sink = sink
+        self.count = 0
+
+
+class G2gAnalyticsBackend(AnalyticsBackend):
+    """`AnalyticsBackend` mapping detections/classifications onto a `MetaSink`."""
+
+    def __init__(self):
+        self._sink = None
+        self._meta = None
+        self._labels = {}  # str -> u32 id
+        self._next_id = 0
+
+    def bind(self, sink):
+        """Bind this frame's sink (called per frame by the g2g element bases).
+        A fresh relation-meta is created lazily on first `add_relation_meta`."""
+        self._sink = sink
+        self._meta = None
+
+    def quark(self, label):
+        """Intern a string label into the `u32` id space the sink expects; ints
+        pass through unchanged (matches the GStreamer GQuark contract)."""
+        if isinstance(label, int):
+            return label
+        qid = self._labels.get(label)
+        if qid is None:
+            qid = self._next_id
+            self._labels[label] = qid
+            self._next_id += 1
+        return qid
+
+    def add_relation_meta(self, buf):
+        if self._sink is None:
+            return None
+        if self._meta is None:
+            self._meta = _RelationMeta(self._sink)
+        return self._meta
+
+    def get_relation_meta(self, buf):
+        return self._meta
+
+    def remove_relation_meta(self, buf):
+        had = self._meta is not None
+        self._meta = None
+        return had
+
+    def relation_length(self, meta):
+        return meta.count if meta else 0
+
+    def add_object(self, meta, label, x, y, w, h, score):
+        if meta is None:
+            return None
+        meta.sink.add_object(
+            self.quark(label), float(x), float(y), float(w), float(h), float(score)
+        )
+        meta.count += 1
+        # Opaque handle: the record's index (used only as a relate() endpoint,
+        # which the flat sink does not support).
+        return meta.count - 1
+
+    def add_classification(self, meta, index, label):
+        if meta is None:
+            return None
+        # The flat sink's add_classification is (label, score); the gst `index`
+        # (stream id) has no place in it and is dropped.
+        meta.sink.add_classification(self.quark(label), 1.0)
+        meta.count += 1
+        return meta.count - 1
+
+    def add_tracking(self, meta, track_id, timestamp=None):
+        # The flat g2g sink stages no tracking records yet.
+        return None
+
+    def relate(self, meta, src, dst):
+        # No relation graph in the flat sink.
+        return False
+
+    def read_objects(self, meta):
+        # The sink is write-only (staged straight into the host frame); the
+        # element cannot read its own staged detections back.
+        return []
+
+
+#: The analytics implementation for this backend (shared singleton; the element
+#: bases bind the per-frame sink on it). Defined here, like `frameio`, to avoid a
+#: circular import through `backend`.
+analytics = G2gAnalyticsBackend()

--- a/plugins/python/backend/g2g/frameio.py
+++ b/plugins/python/backend/g2g/frameio.py
@@ -1,0 +1,90 @@
+# G2gFrameIO (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""Frame buffer I/O backed by the g2g host's `FrameBuffer`.
+
+The g2g host hands each frame to `g2g_process(buf, w, h, fmt, sink)` where `buf`
+is a `FrameBuffer`: a writable buffer-protocol view straight onto the frame's
+system memory (no copy in or out). This backend reads it as a numpy frame, writes
+a processed frame back in place, and routes opaque blobs to the host's `MetaSink`.
+
+Unlike the GStreamer backend there is no muxed/batched buffer: the g2g host
+delivers one source per `FrameBuffer` (batching is the aggregator's job, via
+`g2g_process_batch`), so `read_frames` always reports a single source.
+"""
+
+import numpy as np
+
+from backend.frameio import FrameIO
+
+# Channel count per pixel-format string (the formats VideoTransform negotiates).
+_CHANNELS = {
+    "RGB": 3,
+    "BGR": 3,
+    "RGBA": 4,
+    "ARGB": 4,
+    "BGRA": 4,
+    "ABGR": 4,
+    "GRAY8": 1,
+}
+
+
+class G2gFrameIO(FrameIO):
+    """`FrameIO` over the g2g `FrameBuffer` (pixels) and `MetaSink` (blobs)."""
+
+    def __init__(self):
+        # The per-frame MetaSink, bound by the element at the top of each
+        # g2g_process call so append_blob has somewhere to put side-data.
+        self._sink = None
+        self._fmt = "RGB"
+
+    def bind(self, sink, fmt="RGB"):
+        """Bind the current frame's sink and pixel format (called per frame by
+        the g2g element bases before any read/write)."""
+        self._sink = sink
+        self._fmt = (fmt or "RGB").upper()
+
+    def _channels(self, fmt=None):
+        return _CHANNELS.get((fmt or self._fmt).upper(), 3)
+
+    def read_frame(self, target, source, width, height):
+        c = self._channels()
+        arr = np.frombuffer(target, dtype=np.uint8)
+        if arr.size < width * height * c:
+            return None
+        return arr[: width * height * c].reshape((height, width, c))
+
+    def read_frames(self, target, source, width, height, framerate=(30, 1)):
+        # One source per FrameBuffer; report (frame, num_sources=1, fmt).
+        frame = self.read_frame(target, source, width, height)
+        if frame is None:
+            return None, 0, self._fmt
+        return frame, 1, self._fmt
+
+    def write_frame(self, target, frame):
+        # The FrameBuffer is writable, so frombuffer yields a writable view we
+        # overwrite in place (no copy back to the host).
+        view = np.frombuffer(target, dtype=np.uint8)
+        flat = np.ascontiguousarray(frame, dtype=np.uint8).reshape(-1)
+        n = min(view.size, flat.size)
+        view[:n] = flat[:n]
+        return True
+
+    def append_blob(self, target, header, payload):
+        if self._sink is None:
+            return False
+        hdr = header if isinstance(header, str) else bytes(header).decode("latin-1")
+        self._sink.add_blob(hdr, bytes(payload))
+        return True
+
+
+#: The frame I/O implementation for this backend (shared singleton; the element
+#: bases bind the per-frame sink on it, and leaves use it via `from backend import
+#: frameio`). Defined here (not in the package __init__) so the element bases can
+#: import it without a circular import through `backend`.
+frameio = G2gFrameIO()

--- a/plugins/python/backend/g2g/shims.py
+++ b/plugins/python/backend/g2g/shims.py
@@ -1,0 +1,101 @@
+# Framework-primitive shims (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""Stand-ins for the GStreamer framework primitives leaf elements reference.
+
+The g2g host drives plain-Python objects, not `GstBase` elements: there is no
+GObject type system and no `Gst.FlowReturn`. But leaf element code declares
+`@GObject.Property(...)` for its tunables and returns `FlowReturn.OK/ERROR` from
+its per-frame method. These shims let that same leaf code load and run unchanged
+under the g2g backend (`from backend import GObject, FlowReturn`).
+
+`GObject.Property` becomes a plain descriptor that stores values on the instance
+(or delegates to a getter/setter pair); gst-only metadata (nick, blurb, min/max)
+is accepted and ignored. `FlowReturn` is a plain enum whose `OK`/`ERROR` the host
+treats as success/failure of a frame.
+"""
+
+from enum import IntEnum
+
+
+class FlowReturn(IntEnum):
+    """The subset of `Gst.FlowReturn` leaf per-frame methods return."""
+
+    OK = 0
+    ERROR = -5
+    NOT_LINKED = -1
+    EOS = -3
+
+
+class Property:
+    """Descriptor mimicking `GObject.Property`, in both forms leaves use.
+
+    Decorator form (getter + optional setter)::
+
+        @GObject.Property(type=str)
+        def model_name(self): ...
+        @model_name.setter
+        def model_name(self, value): ...
+
+    Attribute form (plain storage)::
+
+        broker = GObject.Property(type=str, default=None, nick="...", blurb="...")
+
+    Values back a per-instance ``_g2gprop_<name>`` attribute. The ``type`` /
+    ``default`` / ``nick`` / ``blurb`` / ``minimum`` / ``maximum`` keywords are
+    accepted for source compatibility and otherwise ignored (no GObject type
+    system here).
+    """
+
+    def __init__(self, fget=None, *, type=None, default=None, **_gst_meta):
+        self._fget = fget
+        self._fset = None
+        self._default = default
+        self._name = None
+
+    # `GObject.Property(type=str)` returns an instance that is then applied as a
+    # decorator to the getter; this captures it.
+    def __call__(self, fget):
+        self._fget = fget
+        return self
+
+    def setter(self, fset):
+        self._fset = fset
+        return self
+
+    def __set_name__(self, owner, name):
+        self._name = name
+
+    def _slot(self):
+        return f"_g2gprop_{self._name}"
+
+    def __get__(self, obj, owner=None):
+        if obj is None:
+            return self
+        if self._fget is not None:
+            return self._fget(obj)
+        return getattr(obj, self._slot(), self._default)
+
+    def __set__(self, obj, value):
+        if self._fset is not None:
+            self._fset(obj, value)
+        else:
+            setattr(obj, self._slot(), value)
+
+
+class _GObjectShim:
+    """The ``GObject`` namespace leaves import from the backend."""
+
+    Property = Property
+
+    # Some leaves type-hint setters as `prop: GObject.GParamSpec`.
+    class GParamSpec:  # noqa: N801
+        pass
+
+
+GObject = _GObjectShim()

--- a/plugins/python/backend/g2g/transform.py
+++ b/plugins/python/backend/g2g/transform.py
@@ -1,0 +1,134 @@
+# BaseTransform (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""g2g backend for the `transform` element family.
+
+The gst counterpart subclasses `GstBase.BaseTransform`; the g2g element is a
+plain Python object driven by the host's `g2g_process(...)` call. All engine /
+model logic still comes from the portable `MLEngineMixin`; the shared tunable
+properties are declared here with the `GObject` shim so leaf code that reads
+`self._<name>` is unchanged across backends.
+
+The model is loaded lazily on the first frame (`_ensure_model`) rather than from
+a `do_start` framework virtual, since the g2g host has no start hook.
+"""
+
+from backend.core import MLEngineMixin
+from backend.g2g.shims import GObject
+
+
+class BaseTransform(MLEngineMixin):
+    """Base for g2g ML transform elements (same in/out format, e.g. detection)."""
+
+    def __init__(self):
+        self._ml_init()
+
+    @GObject.Property(type=str)
+    def device(self):
+        "Device to run inference on (cpu, cuda, cuda:0, ...)"
+        return self.mgr.device
+
+    @device.setter
+    def device(self, value):
+        self.mgr.set_device(value)
+        if self.mgr.engine_name:
+            self.initialize_engine()
+
+    @GObject.Property(type=int, default=1)
+    def batch_size(self):
+        "Number of items to process in a batch"
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, value):
+        self._batch_size = value
+        if self.engine:
+            self.engine.batch_size = value
+
+    @GObject.Property(type=int, default=1)
+    def frame_stride(self):
+        "How often to process a frame"
+        return self._frame_stride
+
+    @frame_stride.setter
+    def frame_stride(self, value):
+        self._frame_stride = value
+        if self.engine:
+            self.engine.frame_stride = value
+
+    @GObject.Property(type=str)
+    def model_name(self):
+        "Name of the pre-trained model or local model path"
+        return self._model_name
+
+    @model_name.setter
+    def model_name(self, value):
+        self._model_name = value
+
+    @GObject.Property(type=str)
+    def engine_name(self):
+        "ML engine to use: pytorch, onnx, tensorflow, tflite, openvino, ..."
+        return self.mgr.engine_name
+
+    @engine_name.setter
+    def engine_name(self, value):
+        self.mgr.engine_name = value
+
+    @GObject.Property(type=str, default="auto")
+    def input_format(self):
+        "Input tensor layout: auto, nhwc, or nchw"
+        return self.engine.input_format if self.engine else "auto"
+
+    @input_format.setter
+    def input_format(self, value):
+        if self.engine:
+            self.engine.input_format = value
+
+    @GObject.Property(type=str, default="auto")
+    def post_process(self):
+        "Post-processing format for raw engine output"
+        return self.engine.post_process if self.engine else "none"
+
+    @post_process.setter
+    def post_process(self, value):
+        if self.engine:
+            self.engine.post_process = value
+
+    @GObject.Property(type=int, default=1)
+    def device_queue_id(self):
+        "ID of the DeviceQueue from the pool to use"
+        return self._device_queue_id
+
+    @device_queue_id.setter
+    def device_queue_id(self, value):
+        self._device_queue_id = value
+        if self.engine:
+            self.engine.device_queue_id = value
+
+    @GObject.Property(type=bool, default=False)
+    def compile(self):
+        "Enable torch.compile optimization for the model"
+        return self._compile
+
+    @compile.setter
+    def compile(self, value):
+        self._compile = value
+        if value:
+            self.kwargs["compile"] = True
+        else:
+            self.kwargs.pop("compile", None)
+
+    def _ensure_model(self):
+        """Load the model on first use (the g2g host has no start hook).
+
+        Guard on the model, not the engine: setting the `device` property
+        eagerly creates the engine (with no model loaded), so an engine-only
+        check would skip the load and leave inference with a null model.
+        """
+        if self.mgr.engine_name and (self.engine is None or self.engine.model is None):
+            self.do_load_model()

--- a/plugins/python/backend/g2g/video_transform.py
+++ b/plugins/python/backend/g2g/video_transform.py
@@ -1,0 +1,65 @@
+# VideoTransform (g2g backend)
+# Copyright (C) 2024-2026 Collabora Ltd.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+
+"""g2g backend for video transform elements.
+
+The host calls `g2g_process(buf, w, h, fmt, sink)` once per frame. This base
+binds the frame's sink onto the shared `frameio` / `analytics` (so leaf task code
+that calls them through `from backend import frameio, analytics` reaches this
+frame's buffer and sink), extracts the frame, then hands off to `process_frames`,
+the framework-agnostic per-frame hook the leaf element supplies (the same hook the
+gst backend drives from `do_transform_ip`).
+"""
+
+from backend.g2g.analytics import analytics
+from backend.g2g.frameio import frameio
+from backend.g2g.transform import BaseTransform
+
+
+class VideoTransform(BaseTransform):
+    """Base for g2g video transform elements."""
+
+    def __init__(self):
+        super().__init__()
+        self.width = 0
+        self.height = 0
+
+    def process_frames(self, frames, num_sources, fmt, target):
+        """Run inference + write results for one frame (or batch of `num_sources`).
+
+        `frames` is an (H, W, C) array (single source) or (N, H, W, C); `target`
+        is the buffer handle to write a frame back to and to attach metadata to
+        (via `frameio` / `analytics`). The concrete element provides this; the
+        same hook is shared with the gst backend.
+        """
+        raise NotImplementedError("leaf element must implement process_frames")
+
+    def g2g_process(self, buf, width, height, fmt, sink):
+        self.width = width
+        self.height = height
+        # Route this frame's pixels (buf) and metadata sink to the shared I/O the
+        # leaf task code uses.
+        frameio.bind(sink, fmt)
+        analytics.bind(sink)
+        self._ensure_model()
+        frames, num_sources, fmt = frameio.read_frames(buf, None, width, height)
+        if frames is None:
+            return None
+        # The ML elements are RGB-native (in gst this is guaranteed upstream by
+        # videoconvert + RGB sink caps). The g2g host carries 4-channel packed
+        # formats (RGBA / BGRA); with no convert element in the chain, reduce them
+        # to 3-channel RGB here for inference. Detection is read-only, so the
+        # original buffer (write-back target) is untouched.
+        if frames.ndim == 3 and frames.shape[2] == 4:
+            if fmt.upper() in ("BGRA", "ABGR"):
+                frames = frames[:, :, 2::-1]  # B,G,R(,A) -> R,G,B
+            else:
+                frames = frames[:, :, :3]  # R,G,B,A -> R,G,B
+        self.process_frames(frames, num_sources, fmt, buf)
+        # Blobs/detections are staged on the sink; no return payload needed.
+        return None

--- a/tests/test_g2g_backend.py
+++ b/tests/test_g2g_backend.py
@@ -1,0 +1,137 @@
+"""Unit tests for the g2g element backend (`GSTML_BACKEND=g2g`).
+
+These exercise the backend with no GStreamer present: the backend selection, the
+`GObject` / `FlowReturn` shims, the `G2gFrameIO` buffer round-trip, the
+`G2gAnalyticsBackend` mapping onto a flat sink, and an end-to-end `g2g_process`
+on a `VideoTransform` subclass. The g2g host's `FrameBuffer` (a writable
+buffer-protocol view) and `MetaSink` (write-only staging) are stubbed with a
+`bytearray` and a recording object, so no Rust host is needed.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Select the g2g backend before importing `backend`, and make the plugin package
+# importable.
+os.environ["GSTML_BACKEND"] = "g2g"
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "plugins" / "python"))
+
+import backend  # noqa: E402
+from backend import (
+    GObject,
+    FlowReturn,
+    frameio,
+    analytics,
+    VideoTransform,
+)  # noqa: E402
+
+
+class StubMetaSink:
+    """Stand-in for the host's write-only `g2g.MetaSink`."""
+
+    def __init__(self):
+        self.objects = []
+        self.classifications = []
+        self.blobs = []
+
+    def add_object(self, label, x, y, w, h, score):
+        self.objects.append((label, x, y, w, h, score))
+
+    def add_classification(self, label, score):
+        self.classifications.append((label, score))
+
+    def add_blob(self, header, payload):
+        self.blobs.append((header, payload))
+
+
+def test_backend_selected_is_g2g():
+    assert backend.BACKEND == "g2g"
+    assert FlowReturn.OK == 0
+    assert FlowReturn.ERROR != FlowReturn.OK
+
+
+def test_gobject_property_shim_decorator_and_attribute_forms():
+    class Widget:
+        @GObject.Property(type=str)
+        def name(self):
+            return getattr(self, "_n", "default")
+
+        @name.setter
+        def name(self, value):
+            self._n = value.upper()
+
+        size = GObject.Property(type=int, default=7, nick="Size", blurb="px")
+
+    w = Widget()
+    assert w.name == "default"  # getter default
+    w.name = "yolo"
+    assert w.name == "YOLO"  # setter ran
+    assert w.size == 7  # attribute-form default
+    w.size = 42
+    assert w.size == 42
+
+
+def test_frameio_read_write_round_trip():
+    width, height = 4, 3
+    buf = bytearray(width * height * 3)  # RGB, writable buffer-protocol object
+    sink = StubMetaSink()
+    frameio.bind(sink, "RGB")
+
+    frame, num_sources, fmt = frameio.read_frames(buf, None, width, height)
+    assert num_sources == 1 and fmt == "RGB"
+    assert frame.shape == (height, width, 3)
+
+    frameio.write_frame(buf, np.full((height, width, 3), 200, dtype=np.uint8))
+    assert all(b == 200 for b in buf), "write_frame must update the buffer in place"
+
+    frameio.append_blob(buf, "tag", b"\x01\x02")
+    assert sink.blobs == [("tag", b"\x01\x02")]
+
+
+def test_analytics_maps_onto_flat_sink():
+    sink = StubMetaSink()
+    analytics.bind(sink)
+
+    meta = analytics.add_relation_meta(buf=None)
+    assert meta is not None
+    assert analytics.get_relation_meta(None) is meta
+
+    # String labels intern to stable u32 ids (quark), reused across calls.
+    analytics.add_object(meta, "person", 1, 2, 3, 4, 0.9)
+    analytics.add_object(meta, "person", 5, 6, 7, 8, 0.8)
+    analytics.add_object(meta, "handbag", 0, 0, 1, 1, 0.5)
+
+    assert analytics.relation_length(meta) == 3
+    labels = [o[0] for o in sink.objects]
+    assert labels[0] == labels[1], "same string -> same id"
+    assert labels[2] != labels[0], "different string -> different id"
+    assert sink.objects[0][5] == 0.9
+
+
+def test_video_transform_g2g_process_end_to_end():
+    """A VideoTransform subclass inverts the frame and stages one detection,
+    driven exactly as the host drives it: instance.g2g_process(buf, w, h, fmt, sink)."""
+
+    class InvertAndDetect(VideoTransform):
+        def process_frames(self, frames, num_sources, fmt, target):
+            assert num_sources == 1
+            inverted = 255 - frames
+            frameio.write_frame(target, inverted)
+            meta = analytics.add_relation_meta(target)
+            analytics.add_object(meta, "person", 0, 0, 10, 10, 0.99)
+
+    width, height = 8, 8
+    buf = bytearray([10] * (width * height * 3))
+    sink = StubMetaSink()
+
+    elem = InvertAndDetect()
+    ret = elem.g2g_process(buf, width, height, "RGB", sink)
+
+    assert ret is None
+    assert all(b == 245 for b in buf), "frame inverted in place (255 - 10)"
+    assert len(sink.objects) == 1
+    assert sink.objects[0][5] == 0.99
+    assert elem.width == width and elem.height == height

--- a/tests/test_g2g_backend.py
+++ b/tests/test_g2g_backend.py
@@ -128,6 +128,9 @@ def test_video_transform_g2g_process_end_to_end():
     sink = StubMetaSink()
 
     elem = InvertAndDetect()
+    # EngineManager defaults to the pytorch engine, so the first frame would try
+    # to load a model. This test covers the frame plumbing, not inference.
+    elem.engine_name = None
     ret = elem.g2g_process(buf, width, height, "RGB", sink)
 
     assert ret is None


### PR DESCRIPTION
adds a g2g backend under `plugins/python/backend/g2g/`, selected with `GSTML_BACKEND=g2g`. default stays `gst`, so nothing changes unless the variable is set.

the shared seams it plugs into are already on master. this is the backend itself plus its tests, and a ci step to run them.